### PR TITLE
Fixed connection issues

### DIFF
--- a/dataPreprocessing.py
+++ b/dataPreprocessing.py
@@ -1,5 +1,9 @@
 from ucimlrepo import fetch_ucirepo 
   
+import ssl
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
 # fetch dataset 
 heart_disease = fetch_ucirepo(id=45) 
   


### PR DESCRIPTION
This error is caused by an SSL certificate verification failure. Disabling SSL certificate verification by adding the following code before the line that causes the error:

```python
import ssl
ssl._create_default_https_context = ssl._create_unverified_context
```
> The line that causes the error
>> heart_disease = fetch_ucirepo(id=45) 

This will create a new SSL context that does not verify the server's certificate. However, this is not recommended for production environments as it can leave you vulnerable to man-in-the-middle attacks.